### PR TITLE
Add option to disable timeline

### DIFF
--- a/options.html
+++ b/options.html
@@ -18,7 +18,7 @@
     }
 
     section.checkbox > label,
-    section.checkboxlist > label,
+    section.optiongroup > label,
     section.select {
       display: flex;
       justify-content: space-between;
@@ -26,21 +26,21 @@
     }
 
     section.checkbox > label,
-    section.checkboxlist > label {
+    section.optiongroup > label {
       cursor: pointer;
     }
 
-    section.checkboxlist {
+    section.optiongroup {
       padding-left: .825em;
       padding-bottom: .5em;
     }
 
-    section.checkboxlist > label {
+    section.optiongroup > label {
       padding-top: .5em;
       padding-bottom: .5em;
     }
 
-    section.checkboxlist p {
+    section.optiongroup p {
       margin-bottom: .5em;
     }
 
@@ -84,6 +84,10 @@
       background-color: #8AB4F8;
     }
 
+    .switch > input:disabled + label {
+      opacity: .5;
+    }
+
     @media (prefers-color-scheme: dark) {
       body {
         background-color: #202023;
@@ -98,22 +102,30 @@
 </head>
 <body>
   <form>
-    <section class="checkbox">
-      <label>
+    <section class="optiongroup">
+      <p>Timeline settings:</p>
+      <label class="select">
+        Retweets
+        <select name="retweets" id="retweets">
+          <option value="ignore">Do nothing</option>
+          <option value="hide">Hide</option>
+          <option value="separate">Show in separate "Retweets" timeline</option>
+        </select>
+      </label>
+      <label class="checkbox">
         <span>Always use Latest Tweets timeline</span>
         <div class="switch">
           <input type="checkbox" name="alwaysUseLatestTweets" id="alwaysUseLatestTweets">
           <label for="alwaysUseLatestTweets"></label>
         </div>
       </label>
-    </section>
-    <section class="select">
-      Retweets
-      <select name="retweets">
-        <option value="ignore">Do nothing</option>
-        <option value="hide">Hide</option>
-        <option value="separate">Show in separate "Retweets" timeline</option>
-      </select>
+      <label class="checkbox">
+        <span>Disable timeline</span>
+        <div class="switch">
+          <input type="checkbox" name="disableTimeline" id="disableTimeline">
+          <label for="disableTimeline"></label>
+        </div>
+      </label>
     </section>
     <section class="checkbox">
       <label>
@@ -169,7 +181,7 @@
         </div>
       </label>
     </section>
-    <section class="checkboxlist">
+    <section class="optiongroup">
       <p>Hide navigation bar items:</p>
       <label>
         <span>Explore</span>

--- a/options.js
+++ b/options.js
@@ -3,6 +3,7 @@ chrome.storage.local.get((storedConfig) => {
 
   let config = {
     alwaysUseLatestTweets: true,
+    disableTimeline: false,
     enableDebugLogging: false,
     fastBlock: true,
     hideAccountSwitcher: true,
@@ -40,4 +41,17 @@ chrome.storage.local.get((storedConfig) => {
     }
     chrome.storage.local.set(config)
   })
+
+  window.disableTimeline.addEventListener('change', manageTimelineOptions)
+  manageTimelineOptions()
 })
+
+function manageTimelineOptions () {
+  if (window.disableTimeline.checked) {
+    window.alwaysUseLatestTweets.setAttribute('disabled', true)
+    window.retweets.setAttribute('disabled', true)
+  } else {
+    window.alwaysUseLatestTweets.removeAttribute('disabled')
+    window.retweets.removeAttribute('disabled')
+  }
+}

--- a/tweak-new-twitter.user.js
+++ b/tweak-new-twitter.user.js
@@ -4,7 +4,7 @@
 // @namespace   https://github.com/insin/tweak-new-twitter/
 // @match       https://twitter.com/*
 // @match       https://mobile.twitter.com/*
-// @version     27
+// @version     28
 // ==/UserScript==
 
 //#region Config & variables

--- a/tweak-new-twitter.user.js
+++ b/tweak-new-twitter.user.js
@@ -16,6 +16,7 @@
  */
 let config = {
   alwaysUseLatestTweets: true,
+  disableTimeline: false,
   fastBlock: true,
   hideAccountSwitcher: true,
   hideBookmarksNav: true,
@@ -391,6 +392,9 @@ function addStaticCss() {
       `${Selectors.SIDEBAR_COLUMN} section`
     )
   }
+  if (config.disableTimeline) {
+    hideCssSelectors.push(`${Selectors.PRIMARY_NAV} a[href="/home"]`)
+  }
   if (config.hideExploreNav) {
     hideCssSelectors.push(`${Selectors.PRIMARY_NAV} a[href="/explore"]`)
   }
@@ -554,6 +558,11 @@ function onTitleChange(title) {
   // first time.
   if (title == 'Twitter') {
     log('ignoring Flash of Uninitialised Title')
+    return
+  }
+
+  if (config.disableTimeline && location.pathname == '/home') {
+    document.querySelector(`${Selectors.PRIMARY_NAV} a[href="/notifications"]`).click()
     return
   }
 


### PR DESCRIPTION
Thanks for creating this extension! It's been very useful in controlling my Twitter habits.

For my own personal use, I've been tweaking it as a userscript to restrict myself even further. I wanted to cut out the ultimate distraction: the timeline itself. This creates a setup that allows me to post tweets and reply to mentions without the temptation to start scrolling the timeline. This is probably not what most people want, so I've disabled it by default. I do think enough people might find it useful to offer it as an option though. What do you think?

Submitting this as a draft, because I've only implemented the change in the script itself for now. If you're interested in merging this, I'll add it in the extension options form and the readme too.