### PR TITLE
Add support to twitter's Tor site

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,8 @@
     {
       "matches": [
         "https://twitter.com/*",
-        "https://mobile.twitter.com/*"
+        "https://mobile.twitter.com/*",
+        "https://twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion/*"
       ],
       "js": [
         "./tweak-new-twitter.user.js"

--- a/tweak-new-twitter.user.js
+++ b/tweak-new-twitter.user.js
@@ -4,6 +4,7 @@
 // @namespace   https://github.com/insin/tweak-new-twitter/
 // @match       https://twitter.com/*
 // @match       https://mobile.twitter.com/*
+// @match       https://twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion/*
 // @version     56
 // ==/UserScript==
 


### PR DESCRIPTION
This PR tries to add a match to [twitter's official Tor site](https://twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion).

---

ref: https://help.twitter.com/en/using-twitter/twitter-supported-browsers